### PR TITLE
Upgrade @solana/web3.js to 1.93.4 and remove peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@metaplex-foundation/mpl-token-metadata": "3.2.1",
         "@metaplex-foundation/umi": "0.9.1",
         "@solana/spl-token": "0.3.8",
-        "@solana/web3.js": "1.78.4",
+        "@solana/web3.js": "1.93.4",
         "cross-fetch": "3.1.4",
         "dayjs": "1.11.10"
       },
@@ -34,10 +34,6 @@
         "rollup-plugin-peer-deps-external": "2.2.4",
         "tslib": "2.3.1",
         "typescript": "4.4.4"
-      },
-      "peerDependencies": {
-        "@solana/spl-token": "0.3.8",
-        "@solana/web3.js": "1.78.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -144,9 +140,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.1.tgz",
-      "integrity": "sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.8.tgz",
+      "integrity": "sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -471,15 +468,16 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.78.4",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.78.4.tgz",
-      "integrity": "sha512-up5VG1dK+GPhykmuMIozJZBbVqpm77vbOG6/r5dS7NBGZonwHfTLdBbsYc3rjmaQ4DpCXUa3tUc4RZHRORvZrw==",
+      "version": "1.93.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.93.4.tgz",
+      "integrity": "sha512-6hHtSYmkUPwcm3eGeqBanMT3pDAhTprrm2IUoboSjNN4gKCBEkY9uIeS2TZKLpsGY+R6fDub5pRi+e4xFVv55w==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@noble/curves": "^1.0.0",
-        "@noble/hashes": "^1.3.1",
-        "@solana/buffer-layout": "^4.0.0",
-        "agentkeepalive": "^4.3.0",
+        "@babel/runtime": "^7.24.7",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "agentkeepalive": "^4.5.0",
         "bigint-buffer": "^1.1.5",
         "bn.js": "^5.2.1",
         "borsh": "^0.7.0",
@@ -487,10 +485,25 @@
         "buffer": "6.0.3",
         "fast-stable-stringify": "^1.0.0",
         "jayson": "^4.1.0",
-        "node-fetch": "^2.6.12",
-        "rpc-websockets": "^7.5.1",
-        "superstruct": "^0.14.2"
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^1.0.4"
       }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.12.tgz",
+      "integrity": "sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "license": "0BSD"
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -531,6 +544,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -1721,9 +1740,10 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/eyes": {
       "version": "0.1.8",
@@ -2834,7 +2854,8 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "license": "MIT"
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -3057,12 +3078,16 @@
       }
     },
     "node_modules/rpc-websockets": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.9.0.tgz",
-      "integrity": "sha512-DwKewQz1IUA5wfLvgM8wDpPRcr+nWSxuFxx5CbrI2z/MyyZ4nXLM86TvIA+cI1ZAdqC8JIBR1mZR55dzaLU+Hw==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.0.2.tgz",
+      "integrity": "sha512-YzggvfItxMY3Lwuax5rC18inhbjJv9Py7JXRHxTIi94JOLrqBsSsUUc5bbl5W6c11tXhdfpDPK0KzBhoGe8jjw==",
+      "license": "LGPL-3.0-only",
       "dependencies": {
-        "@babel/runtime": "^7.17.2",
-        "eventemitter3": "^4.0.7",
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^8.3.4",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
         "uuid": "^8.3.2",
         "ws": "^8.5.0"
       },
@@ -3075,10 +3100,20 @@
         "utf-8-validate": "^5.0.2"
       }
     },
+    "node_modules/rpc-websockets/node_modules/@types/ws": {
+      "version": "8.5.11",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.11.tgz",
+      "integrity": "sha512-4+q7P5h3SpJxaBft0Dzpbr6lmMaqh0Jr2tbhJZ/luAwvD7ohSCniYkwz/pLxuT2h0EOa6QADgJj1Ko+TzRfZ+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3300,9 +3335,13 @@
       }
     },
     "node_modules/superstruct": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.14.2.tgz",
-      "integrity": "sha512-nPewA6m9mR3d6k7WkZ8N8zpTWfenFH3q9pA2PkuiZxINr9DKB2+40wEQf0ixn8VaGuJ78AB6iWOtStI+/4FKZQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@audius/fetch-nft",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@audius/fetch-nft",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "ISC",
       "dependencies": {
         "@metaplex-foundation/mpl-token-metadata": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@audius/fetch-nft",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "author": "Audius",
   "description": "A utility to fetch Ethereum & Solana NFTs",
   "files": [

--- a/package.json
+++ b/package.json
@@ -39,15 +39,11 @@
     "tslib": "2.3.1",
     "typescript": "4.4.4"
   },
-  "peerDependencies": {
-    "@solana/spl-token": "0.3.8",
-    "@solana/web3.js": "1.78.4"
-  },
   "dependencies": {
     "@metaplex-foundation/mpl-token-metadata": "3.2.1",
     "@metaplex-foundation/umi": "0.9.1",
     "@solana/spl-token": "0.3.8",
-    "@solana/web3.js": "1.78.4",
+    "@solana/web3.js": "1.93.4",
     "cross-fetch": "3.1.4",
     "dayjs": "1.11.10"
   }


### PR DESCRIPTION
Allows the monorepo to upgrade smoothly to 1.93.4 as well, and not conflict with the peer deps